### PR TITLE
Changing IP:PORT to service

### DIFF
--- a/bin/CreateServer
+++ b/bin/CreateServer
@@ -71,16 +71,16 @@ then
     exit
 fi
 
-if [ -d /usr/local/gpx/users/$srv_username/service$tpl_id ]
+if [ -d /usr/local/gpx/users/$srv_username/$srv_ip\-$srv_port ]
 then
     echo "CreateServer: Account directory exists!  Exiting."
     echo "$(date) $(hostname) CreateServer: Account directory exists!  Exiting." >> $srv_log
     if [ "$callback_url" ]; then $cback "$callback_url&do=createsrv_status&status=failed" >> /dev/null; fi
     exit
 else
-    echo "$(date) $(hostname) CreateServer: Creating server directory /usr/local/gpx/users/$srv_username/service$tpl_id ..." >> $srv_log
-    mkdir -p /usr/local/gpx/users/$srv_username/service$tpl_id
-    gpxdir=/usr/local/gpx/users/$srv_username/service$tpl_id
+    echo "$(date) $(hostname) CreateServer: Creating server directory /usr/local/gpx/users/$srv_username/$srv_ip-$srv_port ..." >> $srv_log
+    mkdir -p /usr/local/gpx/users/$srv_username/$srv_ip\-$srv_port
+    gpxdir=/usr/local/gpx/users/$srv_username/$srv_ip-$srv_port
 fi
 
 echo "$(date) $(hostname) CreateServer: Extracting TPL ($tpl_id) to $gpxdir ..." >> $srv_log


### PR DESCRIPTION
Alot of users got that error: libtier0.so cannot open shared object file ... etc, now it won't be anymore, /usr/local/gpx/users/username/192.168.2.101:27015/appID  "192.168.2.101:27015" it will be change with -> "service2" 2 it's the nomber of template :), i wish you luck.
