### PR TITLE
Update debian-init.sh

### DIFF
--- a/initscripts/debian-init.sh
+++ b/initscripts/debian-init.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ### BEGIN INIT INFO
 # Provides:          gpx
 # Required-Start:    $remote_fs $syslog


### PR DESCRIPTION
Added #!/bin/bash line as this was stopping the /etc/init.d/gpx from starting up an thus the FTP service etc as it was causing LSB errors.
This then solved the issue outright and works without issues.

This will be the reason why some people using ubuntu have been reporting that FTP on remote wasn't working.